### PR TITLE
simplify regex for better word matching

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -26,7 +26,7 @@
   let keys = Object.keys(words).sort((x,y) => y.length - x.length);
 
   let escapedWords = "((" + keys.map(w => escapeRegExp(w)).join(")|(") + "))";
-  let regex = new RegExp("(\\s|^)+" + escapedWords + "(([:.;,]+(\\s|$))|\\s|$)", "ig");
+  let regex = new RegExp("(\\b)" + escapedWords + "(\\b)", "ig");
 
   let createLink = function(text) {
       let lower = text.toLowerCase();


### PR DESCRIPTION
Fixes: The plugin does not create a link when a special character comes before or after keyword (e.g. brackets).
Fixes: The plugin does not create a link when 2 keywords are right next to each other (only a space in between) 